### PR TITLE
Update .NET cookbooks with timeout attribute

### DIFF
--- a/ms_dotnet4/attributes/defaults.rb
+++ b/ms_dotnet4/attributes/defaults.rb
@@ -19,3 +19,4 @@
 #
 
 default['ms_dotnet4']['http_url'] = "http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe"
+default['ms_dotnet4']['timeout'] = 600

--- a/ms_dotnet4/metadata.rb
+++ b/ms_dotnet4/metadata.rb
@@ -4,6 +4,6 @@ license           "Apache 2.0"
 license          "All rights reserved"
 description      "Installs/Configures Microsoft .NET 4.0"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.1"
+version          "1.0.2"
 supports         "windows"
 depends          "windows"

--- a/ms_dotnet4/recipes/default.rb
+++ b/ms_dotnet4/recipes/default.rb
@@ -23,6 +23,7 @@ if platform?("windows")
         source node['ms_dotnet4']['http_url']
         installer_type :custom
         options "/quiet /norestart"
+        timeout node['ms_dotnet4']['timeout']
         action :install
        end
 	 end

--- a/ms_dotnet45/attributes/defaults.rb
+++ b/ms_dotnet45/attributes/defaults.rb
@@ -19,3 +19,4 @@
 #
 
 default['ms_dotnet45']['http_url'] = "http://download.microsoft.com/download/b/a/4/ba4a7e71-2906-4b2d-a0e1-80cf16844f5f/dotnetfx45_full_x86_x64.exe"
+default['ms_dotnet45']['timeout'] = 600

--- a/ms_dotnet45/metadata.rb
+++ b/ms_dotnet45/metadata.rb
@@ -4,6 +4,6 @@ license           "Apache 2.0"
 license          "All rights reserved"
 description      "Installs/Configures Microsoft .NET 4.5"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.1.0"
+version          "1.1.1"
 supports	       "windows"
 depends          "windows"

--- a/ms_dotnet45/recipes/default.rb
+++ b/ms_dotnet45/recipes/default.rb
@@ -24,6 +24,7 @@ if platform?("windows")
         source node['ms_dotnet45']['http_url']
         installer_type :custom
         options "/quiet /norestart"
+        timeout node['ms_dotnet45']['timeout']
         action :install
        end
 	 end


### PR DESCRIPTION
Using the ms_dotnet4 and ms_dotnet45 cookbooks we've seen issues with timeout during installation. Updated to specify timeout for install, by default will use the default 600sec.
