### PR TITLE
add name to metadata.rb

### DIFF
--- a/ms_dotnet4/metadata.rb
+++ b/ms_dotnet4/metadata.rb
@@ -1,3 +1,4 @@
+name              "ms_dotnet4"
 maintainer        "Tim Smith - Webtrends Inc"
 maintainer_email  "tim.smith@webtrends.com"
 license           "Apache 2.0"


### PR DESCRIPTION
Berkshelf does not like to upload this cookbook without the name.
